### PR TITLE
#1 fix for: FCML-based HSDIS crashes when used with WinPerfAsmProfiler

### DIFF
--- a/check/public-tests/disassembler_t.c
+++ b/check/public-tests/disassembler_t.c
@@ -25,92 +25,111 @@
 /* Test suite initialization. */
 
 fcml_bool fcml_tf_disassembler_suite_init(void) {
-	return FCML_TRUE;
+    return FCML_TRUE;
 }
 
 fcml_bool fcml_tf_disassembler_suite_cleanup(void) {
-	return FCML_TRUE;
+    return FCML_TRUE;
 }
 
 /* Tests. */
 
+struct fcml_st_td_code_sample {
+    fcml_uint8_t *code;
+    fcml_size len;
+};
+
+fcml_uint8_t td_sampe_instruction_1[] = {0x48, 0x66, 0xFF, 0x57, 0x01};
+fcml_uint8_t td_sampe_instruction_2[] = {0x0F};
+
+struct fcml_st_td_code_sample fcml_td_code_samples[] = {
+    {td_sampe_instruction_1, sizeof(td_sampe_instruction_1)},
+    {td_sampe_instruction_2, sizeof(td_sampe_instruction_2)},
+    {NULL, 0}
+};
+
 void fcml_tf_disassembler_no_instruction_found(void) {
 
-	fcml_uint8_t code[] = { 0x48, 0x66, 0xFF, 0x57, 0x01 };
+    struct fcml_st_td_code_sample *code = &fcml_td_code_samples[0];
 
-	fcml_ceh_error error;
+    while(code->code) {
 
-	/* Initializes the Intel dialect instance. */
-	fcml_st_dialect *dialect;
-	if( ( error = fcml_fn_dialect_init_intel( FCML_INTEL_DIALECT_CF_DEFAULT, &dialect ) ) ) {
-		STF_FAIL("Can not initialize Dialect.");
-		return;
-	}
+        fcml_ceh_error error;
 
-	/* Initializes disassembler for the Intel dialect. */
-	fcml_st_disassembler *disassembler;
-	if( ( error = fcml_fn_disassembler_init( dialect, &disassembler ) ) ) {
-		STF_FAIL("Can not initialize Intel.");
-		fcml_fn_dialect_free( dialect );
-		return;
-	}
+        /* Initializes the Intel dialect instance. */
+        fcml_st_dialect *dialect;
+        if( ( error = fcml_fn_dialect_init_intel( FCML_INTEL_DIALECT_CF_DEFAULT, &dialect ) ) ) {
+            STF_FAIL("Can not initialize Dialect.");
+            return;
+        }
 
-	/* Prepares disassembler result. */
-	fcml_st_disassembler_result dis_result;
-	fcml_fn_disassembler_result_prepare( &dis_result );
+        /* Initializes disassembler for the Intel dialect. */
+        fcml_st_disassembler *disassembler;
+        if( ( error = fcml_fn_disassembler_init( dialect, &disassembler ) ) ) {
+            STF_FAIL("Can not initialize Intel.");
+            fcml_fn_dialect_free( dialect );
+            return;
+        }
 
-	/* Disassembles the code. */
-	fcml_st_disassembler_context context = {0};
-	context.disassembler = disassembler;
-	context.configuration.fail_if_unknown_instruction = FCML_FALSE;
-	context.entry_point.ip = 0x401000;
-	context.entry_point.op_mode = FCML_OM_64_BIT;
-	context.code = code;
-	context.code_length = sizeof( code );
+        /* Prepares disassembler result. */
+        fcml_st_disassembler_result dis_result;
+        fcml_fn_disassembler_result_prepare( &dis_result );
 
-	if( ( error = fcml_fn_disassemble( &context, &dis_result ) ) ) {
-		STF_FAIL("Disassembling failed.");
-		fcml_fn_disassembler_free( disassembler );
-		fcml_fn_dialect_free( dialect );
-		return;
-	}
+        /* Disassembles the code. */
+        fcml_st_disassembler_context context = {0};
+        context.disassembler = disassembler;
+        context.configuration.fail_if_unknown_instruction = FCML_FALSE;
+        context.entry_point.ip = 0x401000;
+        context.entry_point.op_mode = FCML_OM_64_BIT;
+        context.code = code->code;
+        context.code_length = code->len;
 
-	STF_ASSERT_EQUAL( 1, dis_result.instruction.operands_count );
-	STF_ASSERT_EQUAL( FCML_OT_IMMEDIATE, dis_result.instruction.operands[0].type );
-	STF_ASSERT_EQUAL( FCML_DS_8, dis_result.instruction.operands[0].immediate.size );
-	STF_ASSERT_EQUAL( 0x48, dis_result.instruction.operands[0].immediate.int8 );
-	STF_ASSERT_EQUAL( FCML_FALSE, dis_result.instruction.operands[0].immediate.is_signed );
-	STF_ASSERT_EQUAL( FCML_OT_IMMEDIATE, dis_result.instruction.operands[0].type );
-	STF_ASSERT_EQUAL( FP_DB, dis_result.instruction_details.pseudo_op );
-	STF_ASSERT_EQUAL( FCML_FALSE, dis_result.instruction.is_conditional );
-	STF_ASSERT_EQUAL( 0, dis_result.instruction.hints );
-	STF_ASSERT_EQUAL( 0, dis_result.instruction.prefixes );
-	STF_ASSERT_EQUAL( 0, dis_result.instruction_details.addr_mode );
-	STF_ASSERT_EQUAL( 0, dis_result.instruction_details.instruction );
-	STF_ASSERT_EQUAL( 1, dis_result.instruction_details.instruction_size );
-	STF_ASSERT_EQUAL( FCML_FALSE, dis_result.instruction_details.is_shortcut );
-	STF_ASSERT_EQUAL( FCML_FALSE, dis_result.instruction_details.modrm_details.is_modrm );
-	STF_ASSERT_EQUAL( FCML_FALSE, dis_result.instruction_details.modrm_details.is_rip );
-	STF_ASSERT_EQUAL( 0x00, dis_result.instruction_details.modrm_details.modrm );
-	STF_ASSERT_EQUAL( FCML_FALSE, dis_result.instruction_details.modrm_details.sib.is_not_null );
-	STF_ASSERT_EQUAL( 0x00, dis_result.instruction_details.opcode_field_s_bit );
-	STF_ASSERT_EQUAL( 0x00, dis_result.instruction_details.opcode_field_w_bit );
-	STF_ASSERT_EQUAL( 0, dis_result.instruction_details.prefixes_details.prefixes_count );
+        if( ( error = fcml_fn_disassemble( &context, &dis_result ) ) ) {
+            STF_FAIL("Disassembling failed.");
+            fcml_fn_disassembler_free( disassembler );
+            fcml_fn_dialect_free( dialect );
+            return;
+        }
 
-	STF_ASSERT_STRING_EQUAL( "db", dis_result.instruction.mnemonic );
-	STF_ASSERT_EQUAL( F_UNKNOWN, dis_result.instruction_details.instruction );
+        STF_ASSERT_EQUAL( 1, dis_result.instruction.operands_count );
+        STF_ASSERT_EQUAL( FCML_OT_IMMEDIATE, dis_result.instruction.operands[0].type );
+        STF_ASSERT_EQUAL( FCML_DS_8, dis_result.instruction.operands[0].immediate.size );
+        STF_ASSERT_EQUAL( code->code[0], dis_result.instruction.operands[0].immediate.int8 );
+        STF_ASSERT_EQUAL( FCML_FALSE, dis_result.instruction.operands[0].immediate.is_signed );
+        STF_ASSERT_EQUAL( FCML_OT_IMMEDIATE, dis_result.instruction.operands[0].type );
+        STF_ASSERT_EQUAL( FP_DB, dis_result.instruction_details.pseudo_op );
+        STF_ASSERT_EQUAL( FCML_FALSE, dis_result.instruction.is_conditional );
+        STF_ASSERT_EQUAL( 0, dis_result.instruction.hints );
+        STF_ASSERT_EQUAL( 0, dis_result.instruction.prefixes );
+        STF_ASSERT_EQUAL( 0, dis_result.instruction_details.addr_mode );
+        STF_ASSERT_EQUAL( 0, dis_result.instruction_details.instruction );
+        STF_ASSERT_EQUAL( 1, dis_result.instruction_details.instruction_size );
+        STF_ASSERT_EQUAL( FCML_FALSE, dis_result.instruction_details.is_shortcut );
+        STF_ASSERT_EQUAL( FCML_FALSE, dis_result.instruction_details.modrm_details.is_modrm );
+        STF_ASSERT_EQUAL( FCML_FALSE, dis_result.instruction_details.modrm_details.is_rip );
+        STF_ASSERT_EQUAL( 0x00, dis_result.instruction_details.modrm_details.modrm );
+        STF_ASSERT_EQUAL( FCML_FALSE, dis_result.instruction_details.modrm_details.sib.is_not_null );
+        STF_ASSERT_EQUAL( 0x00, dis_result.instruction_details.opcode_field_s_bit );
+        STF_ASSERT_EQUAL( 0x00, dis_result.instruction_details.opcode_field_w_bit );
+        STF_ASSERT_EQUAL( 0, dis_result.instruction_details.prefixes_details.prefixes_count );
 
-	/* Free everything. */
-	fcml_fn_disassembler_result_free( &dis_result );
-	fcml_fn_disassembler_free( disassembler );
-	fcml_fn_dialect_free( dialect );
+        STF_ASSERT_STRING_EQUAL( "db", dis_result.instruction.mnemonic );
+        STF_ASSERT_EQUAL( F_UNKNOWN, dis_result.instruction_details.instruction );
+
+        /* Free everything. */
+        fcml_fn_disassembler_result_free( &dis_result );
+        fcml_fn_disassembler_free( disassembler );
+        fcml_fn_dialect_free( dialect );
+
+        code++;
+    }
 }
 
 fcml_stf_test_case fcml_ti_disassembler[] = {
-	{ "fcml_tf_disassembler_no_instruction_found", fcml_tf_disassembler_no_instruction_found },
-	FCML_STF_NULL_TEST
+    { "fcml_tf_disassembler_no_instruction_found", fcml_tf_disassembler_no_instruction_found },
+    FCML_STF_NULL_TEST
 };
 
 fcml_stf_test_suite fcml_si_disassembler = {
-	"suite-fcml-disassembler", fcml_tf_disassembler_suite_init, fcml_tf_disassembler_suite_cleanup, fcml_ti_disassembler
+    "suite-fcml-disassembler", fcml_tf_disassembler_suite_init, fcml_tf_disassembler_suite_cleanup, fcml_ti_disassembler
 };

--- a/check/public-tests/disassembler_t.c
+++ b/check/public-tests/disassembler_t.c
@@ -39,12 +39,12 @@ struct fcml_st_td_code_sample {
     fcml_size len;
 };
 
-fcml_uint8_t td_sampe_instruction_1[] = {0x48, 0x66, 0xFF, 0x57, 0x01};
-fcml_uint8_t td_sampe_instruction_2[] = {0x0F};
+fcml_uint8_t td_sample_instruction_1[] = {0x48, 0x66, 0xFF, 0x57, 0x01};
+fcml_uint8_t td_sample_instruction_2[] = {0x0F};
 
 struct fcml_st_td_code_sample fcml_td_code_samples[] = {
-    {td_sampe_instruction_1, sizeof(td_sampe_instruction_1)},
-    {td_sampe_instruction_2, sizeof(td_sampe_instruction_2)},
+    {td_sample_instruction_1, sizeof(td_sample_instruction_1)},
+    {td_sample_instruction_2, sizeof(td_sample_instruction_2)},
     {NULL, 0}
 };
 

--- a/src/fcml_decoding_tree.c
+++ b/src/fcml_decoding_tree.c
@@ -60,8 +60,9 @@ fcml_ceh_error fcml_ifn_dt_dts_default_opcode_callback( fcml_st_dt_decoding_tree
     fcml_st_dt_diss_tree_element **current_elements = &( dec_tree->opcode[0] );
     fcml_st_dt_diss_tree_element *element = NULL;
 
-    /* Looking for a node in the instruction tree where new instruction should be placed. If there is no
-     /* appropriate node a new one is allocated.
+    /* Looking for a node in the instruction tree where new
+     * instruction should be placed. If there is no appropriate
+     * node a new one is allocated.
      */
     int i;
     int opcode_num = FCML_DEF_OPCODE_FLAGS_OPCODE_NUM( opcode_desc->opcode_flags );
@@ -99,7 +100,7 @@ fcml_ceh_error fcml_ifn_dt_dts_handle_next_opcode_byte( fcml_st_dt_decoding_tree
 
     /* Get next opcode byte from instruction.*/
     if (opcode_byte_num == opcode_bytes_count) {
-        /* There is no more opcode bytes available.*/
+        /* There are no more opcode bytes available.*/
         return callback( dec_tree, instruction_desc, opcode_desc, opcodes );
     }
 
@@ -177,7 +178,7 @@ int fcml_ifn_dt_dts_update_disassembling_tree( fcml_st_def_instruction_desc *ins
         for ( opcode_index = 0; opcode_index < instruction_desc->opcode_desc_count; opcode_index++ ) {
             struct fcml_st_def_addr_mode_desc *opcode_desc = &( instruction_desc->addr_modes[opcode_index] );
 
-            /* Iterate through all opcode combination for this instruction form.*/
+            /* Iterate through all opcode combinations for this instruction form.*/
             int error = fcml_ifn_dt_dts_iterate_through_all_opcodes( dec_tree, instruction_desc, opcode_desc, &fcml_ifn_dt_dts_default_opcode_callback );
             if (error) {
                 break;

--- a/src/fcml_disassembler.c
+++ b/src/fcml_disassembler.c
@@ -38,20 +38,20 @@
 #include "fcml_messages.h"
 
 /* R,X and B are stored in 1's complement form.*/
-#define FCML_VEX_W(x)				FCML_TP_GET_BIT(x, 7)
-#define FCML_VEX_R(x)				!FCML_TP_GET_BIT(x, 7)
-#define FCML_VEX_X(x)				!FCML_TP_GET_BIT(x, 6)
-#define FCML_VEX_B(x)				!FCML_TP_GET_BIT(x, 5)
-#define FCML_VEX_L(x)				FCML_TP_GET_BIT(x, 2)
-#define FCML_VEX_MMMM(x)			( x & 0x1F )
-#define FCML_VEX_VVVV(x)			( ~( ( x & 0x78 ) >> 3 ) & 0x00F )
-#define FCML_VEX_PP(x)				( x & 0x03 )
+#define FCML_VEX_W(x)                FCML_TP_GET_BIT(x, 7)
+#define FCML_VEX_R(x)                !FCML_TP_GET_BIT(x, 7)
+#define FCML_VEX_X(x)                !FCML_TP_GET_BIT(x, 6)
+#define FCML_VEX_B(x)                !FCML_TP_GET_BIT(x, 5)
+#define FCML_VEX_L(x)                FCML_TP_GET_BIT(x, 2)
+#define FCML_VEX_MMMM(x)             ( x & 0x1F )
+#define FCML_VEX_VVVV(x)             ( ~( ( x & 0x78 ) >> 3 ) & 0x00F )
+#define FCML_VEX_PP(x)               ( x & 0x03 )
 
 /* REX prefix fields.*/
-#define FCML_REX_W(x)					FCML_TP_GET_BIT(x, 3)
-#define FCML_REX_R(x)					FCML_TP_GET_BIT(x, 2)
-#define FCML_REX_X(x)					FCML_TP_GET_BIT(x, 1)
-#define FCML_REX_B(x)					FCML_TP_GET_BIT(x, 0)
+#define FCML_REX_W(x)                FCML_TP_GET_BIT(x, 3)
+#define FCML_REX_R(x)                FCML_TP_GET_BIT(x, 2)
+#define FCML_REX_X(x)                FCML_TP_GET_BIT(x, 1)
+#define FCML_REX_B(x)                FCML_TP_GET_BIT(x, 0)
 
 typedef struct fcml_ist_dasm_operand_wrapper {
     fcml_st_operand operand;
@@ -1695,10 +1695,7 @@ fcml_ceh_error fcml_ifn_dasm_instruction_decoder_IA( fcml_ist_dasm_decoding_cont
 fcml_ceh_error fcml_ifn_prepare_pseudo_operation( fcml_ist_dasm_decoding_context *context ) {
 
     /* Seek to the beginning of the stream. */
-    fcml_int prefixes_count = context->prefixes.prefixes_count;
-    if ( prefixes_count ) {
-        fcml_fn_stream_seek( context->stream, -prefixes_count, FCML_EN_ST_CURRENT );
-    }
+    fcml_fn_stream_seek( context->stream, 0, FCML_EN_ST_START );
 
     /* Clean whole decoding context, because there might be
      * remains of the previous processing.
@@ -1779,7 +1776,7 @@ fcml_ceh_error fcml_ifn_dasm_decode_instruction( fcml_ist_dasm_decoding_context 
     fcml_bool found = FCML_FALSE;
 
     /* Disassemble instruction using most appropriate addressing mode from disassembling tree. */
-    if ( tree_element ) {
+    if ( tree_element && tree_element->instruction_decoding_defs ) {
 
         fcml_st_coll_list_element *current = tree_element->instruction_decoding_defs->head;
         while ( current ) {
@@ -1831,15 +1828,15 @@ fcml_ceh_error fcml_ifn_dasm_decode_instruction( fcml_ist_dasm_decoding_context 
  * Prefixes decoding.
  ****************************/
 
-#define FCML_IDFPF_IS_MANDATORY_CANDIDATE		0x0001
-#define FCML_IDFPF_IS_LOCK						0x0002
-#define FCML_IDFPF_IS_REP_XRELEASE				0x0004
-#define FCML_IDFPF_IS_REPNE_XACQUIRE			0x0008
-#define FCML_IDFPF_IS_VEX						0x0010
-#define FCML_IDFPF_IS_XOP						0x0020
-#define FCML_IDFPF_IS_BRANCH					0x0040
-#define FCML_IDFPF_IS_XOP_ALLOWED				0x0080
-#define FCML_IDFPF_IS_NOBRANCH					0x0100
+#define FCML_IDFPF_IS_MANDATORY_CANDIDATE       0x0001
+#define FCML_IDFPF_IS_LOCK                      0x0002
+#define FCML_IDFPF_IS_REP_XRELEASE              0x0004
+#define FCML_IDFPF_IS_REPNE_XACQUIRE            0x0008
+#define FCML_IDFPF_IS_VEX                       0x0010
+#define FCML_IDFPF_IS_XOP                       0x0020
+#define FCML_IDFPF_IS_BRANCH                    0x0040
+#define FCML_IDFPF_IS_XOP_ALLOWED               0x0080
+#define FCML_IDFPF_IS_NOBRANCH                  0x0100
 
 fcml_ceh_error fcml_ifn_dasm_decode_prefixes( fcml_ist_dasm_decoding_context *decoding_context ) {
 


### PR DESCRIPTION
A bug fix for problem described in #1 and minor reformatting and typos fixes.
