### PR TITLE
add missing FCML_STF_NULL_TEST to symbols test

### DIFF
--- a/check/internal-tests/symbols_t.c
+++ b/check/internal-tests/symbols_t.c
@@ -46,6 +46,7 @@ void fcml_tf_symbols_alloc() {
 
 fcml_stf_test_case fctl_ti_symbols[] = {
 	{ "fcml_tf_symbols_alloc", fcml_tf_symbols_alloc },
+	FCML_STF_NULL_TEST
 };
 
 fcml_stf_test_suite fctl_si_symbols = {


### PR DESCRIPTION
Fcml FTBFS on Debian for mips64el with following error:

```
make  check-TESTS
make[4]: Entering directory '/«PKGBUILDDIR»/check/internal-tests'
make[5]: Entering directory '/«PKGBUILDDIR»/check/internal-tests'
../../test-driver: line 107: 10353 Segmentation fault      "$@" > $log_file 2>&1
FAIL: fcml_internal_check
=====================================================
   fcml 1.1.1: check/internal-tests/test-suite.log
=====================================================

# TOTAL: 1
# PASS:  0
# SKIP:  0
# XFAIL: 0
# FAIL:  1
# XPASS: 0
# ERROR: 0

.. contents:: :depth: 2

FAIL: fcml_internal_check
```

Full log: https://buildd.debian.org/status/fetch.php?pkg=fcml&arch=mips64el&ver=1.1.1-2&stamp=1466938055

I tried to build fcml on i386, it also segfaulted on fcml_internal_check.

The reason of segmentation fault is a missing NULL in fcml_stf_test_case fctl_ti_symbols
