### PR TITLE
Hide non-public symbols with GCC

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -114,6 +114,13 @@ AS_CASE(
 	)]
 )
 
+# Check whether the compiler can hide symbols
+VISIBILITY_CFLAGS=""
+AS_COMPILER_FLAG([-fvisibility=hidden], [VISIBILITY_CFLAGS="-fvisibility=hidden"])
+AC_SUBST(VISIBILITY_CFLAGS)
+
+CFLAGS="$CFLAGS $VISIBILITY_CFLAGS"
+
 AC_OUTPUT
 echo "***************************************************
 ${PACKAGE_NAME} version ${PACKAGE_VERSION}

--- a/example/hsdis/hsdis.c
+++ b/example/hsdis/hsdis.c
@@ -70,7 +70,7 @@
 #define ADDR_FORM	FCML_OM_32_BIT
 #endif
 
-char HELP[] = "Optional arguments:\n"
+__attribute__((visibility("default"))) char HELP[] = "Optional arguments:\n"
         " code - Print machine code before mnemonic.\n"
         " intel - Use intel dialect.\n"
         " gas - Use GNU assembler dialect (AT&T).\n"
@@ -105,7 +105,7 @@ typedef struct hsdis_app {
 void parse_options(hsdis_app *app);
 void prepare_render_config(fcml_st_render_config *config, hsdis_app *app);
 
-void* HSDIS_CALL decode_instructions(void *start, void *end,
+__attribute__((visibility("default"))) void* HSDIS_CALL decode_instructions(void *start, void *end,
         jvm_event_callback event_callback, void *event_stream,
         jvm_printf_callback printf_callback, void *printf_stream,
         const char *options) {
@@ -238,7 +238,7 @@ void* HSDIS_CALL decode_instructions(void *start, void *end,
 
 }
 
-void prepare_render_config(fcml_st_render_config *config, hsdis_app *app) {
+__attribute__((visibility("default"))) void prepare_render_config(fcml_st_render_config *config, hsdis_app *app) {
 
     config->render_flags = ( FCML_REND_FLAG_RENDER_INDIRECT_HINT
             | FCML_REND_FLAG_RENDER_ABS_HINT |
@@ -271,7 +271,7 @@ void prepare_render_config(fcml_st_render_config *config, hsdis_app *app) {
     }
 }
 
-void parse_options(hsdis_app *app) {
+__attribute__((visibility("default"))) void parse_options(hsdis_app *app) {
 
 #ifdef FCML_MSCC
 	/* Intel dialect by default for Microsoft compilers. */

--- a/include/fcml_lib_export.h
+++ b/include/fcml_lib_export.h
@@ -53,7 +53,7 @@
 #endif
 
 #ifndef LIB_EXPORT
-#define LIB_EXPORT
+#define LIB_EXPORT __attribute__((visibility("default")))
 #endif
 
 #ifndef LIB_CALL


### PR DESCRIPTION
This checks whether the compiler and linker support
-fvisibility=hidden, and if so, uses it to link the library, thus
hiding symbols which aren't intended for public consumption.

hsdis needs a number of its symbols to be exported, so this also
changes hsdis.c to explicitly export the necessary symbols.

Signed-off-by: Stephen Kitt <steve@sk2.org>