### PR TITLE
Conditionally hide non-public symbols with GCC.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,10 +3,11 @@ jobs:
     docker:
       - image: ubuntu:20.04
     steps:
-      - checkout
       - run: |
           apt-get update -qq
           apt-get install build-essential autoconf libtool-bin flex bison -y
+      - checkout
+      - run: |
           autoreconf -i
           ./configure
           make && make check

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,7 @@ jobs:
     steps:
       - run: |
           apt-get update -qq
-          apt-get install build-essential autoconf libtool-bin flex bison -y
+          apt-get install build-essential autoconf libtool-bin flex bison git -y
       - checkout
       - run: |
           autoreconf -i

--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,4 @@ test-driver
 *.opendb
 *.db-shm
 *.db-wal
-m4/*.m4
-!m4/as-compiler-flag.m4
 

--- a/.gitignore
+++ b/.gitignore
@@ -35,4 +35,6 @@ test-driver
 *.opendb
 *.db-shm
 *.db-wal
+m4/*.m4
+!m4/as-compiler-flag.m4
 

--- a/configure.ac
+++ b/configure.ac
@@ -114,6 +114,13 @@ AS_CASE(
 	)]
 )
 
+# Check whether the compiler can hide symbols
+VISIBILITY_CFLAGS=""
+AS_COMPILER_FLAG([-fvisibility=hidden], [VISIBILITY_CFLAGS="-fvisibility=hidden"])
+AC_SUBST(VISIBILITY_CFLAGS)
+
+CFLAGS="$CFLAGS $VISIBILITY_CFLAGS"
+
 AC_OUTPUT
 echo "***************************************************
 ${PACKAGE_NAME} version ${PACKAGE_VERSION}

--- a/configure.ac
+++ b/configure.ac
@@ -2,7 +2,7 @@
 # Process this file with autoconf to produce a configure script.
 
 AC_PREREQ([2.69])
-AC_INIT([fcml], [1.2.3], [bugs@fcml-lib.com])
+AC_INIT([fcml], [1.2.3], [slawomir.wojtasiak@fcml-lib.com])
 AM_INIT_AUTOMAKE
 LT_PREREQ([2.2])
 LT_INIT[win32-dll]
@@ -118,6 +118,9 @@ AS_CASE(
 VISIBILITY_CFLAGS=""
 AS_COMPILER_FLAG([-fvisibility=hidden], [VISIBILITY_CFLAGS="-fvisibility=hidden"])
 AC_SUBST(VISIBILITY_CFLAGS)
+
+AS_IF([test -n "$VISIBILITY_CFLAGS"],
+    [AC_DEFINE([SUPPORT_VISIBILITY_HIDDEN], [1], [Support for -fvisibility=hidden flag.])])
 
 CFLAGS="$CFLAGS $VISIBILITY_CFLAGS"
 

--- a/example/hsdis/hsdis.c
+++ b/example/hsdis/hsdis.c
@@ -1,6 +1,6 @@
 /*
  * FCML - Free Code Manipulation Library.
- * Copyright (C) 2010-2020 Slawomir Wojtasiak
+ * Copyright (C) 2010-2021 Slawomir Wojtasiak
  * 
  * This piece of software is available under LGPL or Apache License.
  * 
@@ -29,7 +29,7 @@
  *
  * Apache License:
  * 
- * Copyright 2010-2019 Sławomir Wojtasiak
+ * Copyright 2010-2021 Sławomir Wojtasiak
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -64,13 +64,12 @@
 #if _M_X64 || __x86_64__
 #define MACH_ARCH	"amd64"
 #define ADDR_FORM	FCML_OM_64_BIT
-/* 64-bit */
 #else
 #define MACH_ARCH	"i386"
 #define ADDR_FORM	FCML_OM_32_BIT
 #endif
 
-__attribute__((visibility("default"))) char HELP[] = "Optional arguments:\n"
+static char HELP[] = "Optional arguments:\n"
         " code - Print machine code before mnemonic.\n"
         " intel - Use intel dialect.\n"
         " gas - Use GNU assembler dialect (AT&T).\n"
@@ -102,10 +101,10 @@ typedef struct hsdis_app {
     hdis_config config;
 } hsdis_app;
 
-void parse_options(hsdis_app *app);
-void prepare_render_config(fcml_st_render_config *config, hsdis_app *app);
+static void parse_options(hsdis_app *app);
+static void prepare_render_config(fcml_st_render_config *config, hsdis_app *app);
 
-__attribute__((visibility("default"))) void* HSDIS_CALL decode_instructions(void *start, void *end,
+void* HSDIS_CALL decode_instructions(void *start, void *end,
         jvm_event_callback event_callback, void *event_stream,
         jvm_printf_callback printf_callback, void *printf_stream,
         const char *options) {
@@ -238,7 +237,7 @@ __attribute__((visibility("default"))) void* HSDIS_CALL decode_instructions(void
 
 }
 
-__attribute__((visibility("default"))) void prepare_render_config(fcml_st_render_config *config, hsdis_app *app) {
+static void prepare_render_config(fcml_st_render_config *config, hsdis_app *app) {
 
     config->render_flags = ( FCML_REND_FLAG_RENDER_INDIRECT_HINT
             | FCML_REND_FLAG_RENDER_ABS_HINT |
@@ -271,7 +270,7 @@ __attribute__((visibility("default"))) void prepare_render_config(fcml_st_render
     }
 }
 
-__attribute__((visibility("default"))) void parse_options(hsdis_app *app) {
+static void parse_options(hsdis_app *app) {
 
 #ifdef FCML_MSCC
 	/* Intel dialect by default for Microsoft compilers. */
@@ -319,5 +318,4 @@ __attribute__((visibility("default"))) void parse_options(hsdis_app *app) {
 
         current = strchr(current, ',');
     }
-
 }

--- a/example/hsdis/hsdis.c
+++ b/example/hsdis/hsdis.c
@@ -70,7 +70,7 @@
 #define ADDR_FORM	FCML_OM_32_BIT
 #endif
 
-char HELP[] = "Optional arguments:\n"
+__attribute__((visibility("default"))) char HELP[] = "Optional arguments:\n"
         " code - Print machine code before mnemonic.\n"
         " intel - Use intel dialect.\n"
         " gas - Use GNU assembler dialect (AT&T).\n"
@@ -105,7 +105,7 @@ typedef struct hsdis_app {
 void parse_options(hsdis_app *app);
 void prepare_render_config(fcml_st_render_config *config, hsdis_app *app);
 
-void* HSDIS_CALL decode_instructions(void *start, void *end,
+__attribute__((visibility("default"))) void* HSDIS_CALL decode_instructions(void *start, void *end,
         jvm_event_callback event_callback, void *event_stream,
         jvm_printf_callback printf_callback, void *printf_stream,
         const char *options) {
@@ -238,7 +238,7 @@ void* HSDIS_CALL decode_instructions(void *start, void *end,
 
 }
 
-void prepare_render_config(fcml_st_render_config *config, hsdis_app *app) {
+__attribute__((visibility("default"))) void prepare_render_config(fcml_st_render_config *config, hsdis_app *app) {
 
     config->render_flags = ( FCML_REND_FLAG_RENDER_INDIRECT_HINT
             | FCML_REND_FLAG_RENDER_ABS_HINT |
@@ -271,7 +271,7 @@ void prepare_render_config(fcml_st_render_config *config, hsdis_app *app) {
     }
 }
 
-void parse_options(hsdis_app *app) {
+__attribute__((visibility("default"))) void parse_options(hsdis_app *app) {
 
 #ifdef FCML_MSCC
 	/* Intel dialect by default for Microsoft compilers. */

--- a/example/hsdis/hsdis.h
+++ b/example/hsdis/hsdis.h
@@ -1,6 +1,6 @@
 /*
  * FCML - Free Code Manipulation Library.
- * Copyright (C) 2010-2020 Slawomir Wojtasiak
+ * Copyright (C) 2010-2021 Slawomir Wojtasiak
  * 
  * This piece of software is available under LGPL or Apache License.
  * 
@@ -29,7 +29,7 @@
  *
  * Apache License:
  * 
- * Copyright 2010-2017 Sławomir Wojtasiak
+ * Copyright 2010-2021 Sławomir Wojtasiak
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -58,8 +58,14 @@
 #endif
 #endif
 
+/* If HSDIS_API is not defined here try to use the standard exporting
+ * macro from fcml-lib. */
 #ifndef HSDIS_API
+#ifdef LIB_EXPORT
+#define HSDIS_API LIB_EXPORT
+#else
 #define HSDIS_API
+#endif
 #endif
 
 #ifdef FCML_MSCC

--- a/include/fcml_lib_export.h
+++ b/include/fcml_lib_export.h
@@ -1,6 +1,6 @@
 /*
  * FCML - Free Code Manipulation Library.
- * Copyright (C) 2010-2020 Slawomir Wojtasiak
+ * Copyright (C) 2010-2021 Slawomir Wojtasiak
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -30,7 +30,7 @@
  * in fact you should define the symbol before including anything from the FCML library.
  * This declaration can be omitted as long as you use undecorated symbol names.
  *
- * @copyright Copyright (C) 2010-2020 Slawomir Wojtasiak. All rights reserved.
+ * @copyright Copyright (C) 2010-2021 Slawomir Wojtasiak. All rights reserved.
  * This project is released under the GNU Lesser General Public License.
  */
 
@@ -53,7 +53,11 @@
 #endif
 
 #ifndef LIB_EXPORT
+#ifdef SUPPORT_VISIBILITY_HIDDEN
 #define LIB_EXPORT __attribute__((visibility("default")))
+#else
+#define LIB_EXPORT
+#endif
 #endif
 
 #ifndef LIB_CALL

--- a/include/fcml_lib_export.h
+++ b/include/fcml_lib_export.h
@@ -53,7 +53,7 @@
 #endif
 
 #ifndef LIB_EXPORT
-#define LIB_EXPORT
+#define LIB_EXPORT __attribute__((visibility("default")))
 #endif
 
 #ifndef LIB_CALL

--- a/m4/.gitignore
+++ b/m4/.gitignore
@@ -1,1 +1,3 @@
 *.m4
+!as-compiler-flag.m4
+

--- a/m4/.gitignore
+++ b/m4/.gitignore
@@ -1,0 +1,3 @@
+*.m4
+!as-compiler-flag.m4
+

--- a/m4/.gitignore
+++ b/m4/.gitignore
@@ -1,3 +1,0 @@
-*.m4
-!as-compiler-flag.m4
-

--- a/m4/as-compiler-flag.m4
+++ b/m4/as-compiler-flag.m4
@@ -1,0 +1,62 @@
+dnl as-compiler-flag.m4 0.1.0
+
+dnl autostars m4 macro for detection of compiler flags
+
+dnl David Schleef <ds@schleef.org>
+
+dnl $Id: as-compiler-flag.m4,v 1.1 2005/12/15 23:35:19 ds Exp $
+
+dnl AS_COMPILER_FLAG(CFLAGS, ACTION-IF-ACCEPTED, [ACTION-IF-NOT-ACCEPTED])
+dnl Tries to compile with the given CFLAGS.
+dnl Runs ACTION-IF-ACCEPTED if the compiler can compile with the flags,
+dnl and ACTION-IF-NOT-ACCEPTED otherwise.
+
+AC_DEFUN([AS_COMPILER_FLAG],
+[
+  AC_MSG_CHECKING([to see if compiler understands $1])
+
+  save_CFLAGS="$CFLAGS"
+  CFLAGS="$CFLAGS $1"
+
+  AC_TRY_COMPILE([ ], [], [flag_ok=yes], [flag_ok=no])
+  CFLAGS="$save_CFLAGS"
+
+  if test "X$flag_ok" = Xyes ; then
+    m4_ifvaln([$2],[$2])
+    true
+  else
+    m4_ifvaln([$3],[$3])
+    true
+  fi
+  AC_MSG_RESULT([$flag_ok])
+])
+
+dnl AS_COMPILER_FLAGS(VAR, FLAGS)
+dnl Tries to compile with the given CFLAGS.
+
+AC_DEFUN([AS_COMPILER_FLAGS],
+[
+  list=$2
+  flags_supported=""
+  flags_unsupported=""
+  AC_MSG_CHECKING([for supported compiler flags])
+  for each in $list
+  do
+    save_CFLAGS="$CFLAGS"
+    CFLAGS="$CFLAGS $each"
+    AC_TRY_COMPILE([ ], [], [flag_ok=yes], [flag_ok=no])
+    CFLAGS="$save_CFLAGS"
+
+    if test "X$flag_ok" = Xyes ; then
+      flags_supported="$flags_supported $each"
+    else
+      flags_unsupported="$flags_unsupported $each"
+    fi
+  done
+  AC_MSG_RESULT([$flags_supported])
+  if test "X$flags_unsupported" != X ; then
+    AC_MSG_WARN([unsupported compiler flags: $flags_unsupported])
+  fi
+  $1="$$1 $flags_supported"
+])
+


### PR DESCRIPTION
Stephen,

This PR is based on the one you've provided. Unfortunately there is no way to provide a change proposal for an external one, so I decided to inherit all the commits from it and to prepare this one.

It's a really nice idea to hide all the symbols which are not explicitly exported also for Unix like systems.

You're right, the explicitly added `__attribute__((visibility("default")))` might cause some problems if the used compiler doesn't support it. I did some experiments and decided to add the conditional check you mentioned.

It looks like everything works as expected for the lib itself as well as for hsdis.

Regarding the symbols exported by `hsdis` do we need anything more than `decode_instructions`? I thought it should be enough, but to be honest I don't remember at the moment. I'll check if it works soon.

Please take a look at the code.
